### PR TITLE
Return result as an object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,10 +20,9 @@
       }
     },
     "@feathersjs/errors": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-3.2.2.tgz",
-      "integrity": "sha512-j2SiZBUimcUAFXGnmiByQKV+8/OehnJFGP5wT3XKjU6nyiLft6Av5ti1/sRV+ji2Tu80H6YVfhIoVG8ndEpBnA==",
-      "dev": true,
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-3.3.0.tgz",
+      "integrity": "sha512-9oYAhAj4CKIix5KITRDEzvyNJNIaqNde5lGqmrQLw4pTuyWMvx9tgBhtXPA0l8lS1KnMKw4Qf1gHo6aKrM+OyQ==",
       "requires": {
         "debug": "3.1.0"
       }
@@ -35,7 +34,7 @@
       "dev": true,
       "requires": {
         "@feathersjs/commons": "1.4.0",
-        "@feathersjs/errors": "3.2.2",
+        "@feathersjs/errors": "3.3.0",
         "debug": "3.1.0",
         "express": "4.16.2",
         "uberproto": "1.2.0"
@@ -1941,7 +1940,7 @@
       "dev": true,
       "requires": {
         "@feathersjs/commons": "1.4.0",
-        "@feathersjs/errors": "3.2.2",
+        "@feathersjs/errors": "3.3.0",
         "clone-deep": "2.0.2",
         "sift": "5.0.0",
         "uberproto": "1.2.0"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "@feathersjs/commons": "^1.4.0",
+    "@feathersjs/errors": "^3.3.0",
     "async": "^2.6.0",
     "debug": "^3.1.0"
   },

--- a/src/batch.js
+++ b/src/batch.js
@@ -19,7 +19,7 @@ export default function () {
       const type = data.type || 'parallel';
 
       if (Array.isArray(data.call) && !data.call.length) {
-        return { type, results: [] };
+        return { type, data: [] };
       }
 
       if (!(data.call instanceof Object)) {

--- a/src/batch.js
+++ b/src/batch.js
@@ -4,12 +4,14 @@
 // https://github.com/babel/babel/issues/5085
 import 'babel-polyfill';
 import async from 'async';
+import errors from '@feathersjs/errors'
 
 const paramsPositions = {
   find: 0,
   update: 2,
   patch: 2
 };
+
 
 export default function () {
   return {
@@ -48,11 +50,11 @@ export default function () {
 
         const runner = async () => {
           if (!service) {
-            throw new Error(`Service ${path} does not exist`);
+            throw new errors.NotFound(`Service ${path} does not exist`);
           }
 
           if (!method || typeof service[method] !== 'function') {
-            throw new Error(
+            throw new errors.MethodNotAllowed(
               `Method ${method} on service ${path} does not exist`
             );
           }

--- a/test/batch.js
+++ b/test/batch.js
@@ -28,7 +28,7 @@ describe('feathers-batch tests', () => {
     app.use('/batch', batcher());
 
     const data = await app.service('batch').create({call: []}, {});
-    assert.deepEqual(data, {type: 'parallel', results: []});
+    assert.deepEqual(data, {type: 'parallel', data: []});
   });
 
   it('simple batching in series with one service and one error', async () => {


### PR DESCRIPTION
It is much more comfortable to modify code that uses batch service if call results are accessed by call aliases instead of indexes which tend to change on call order modification.

For example, the `const args = {...}` block with magic indexes can be removed from this code:

    function checkResults(data) {
        for (let [key, value] of Object.entries(data)) {
            if (value[0]) {
                throw new Error(`Batch call '${key}' failed: ${value[0]}`)
            }
            data[key] = value[1]
        }
    }

    async function handler(req, res) {
        const {data} = await api.service('batch').create({
            call: [
                ['cities::find'],
                ['posts::find'],
                ['comments::find'],
            ]
        })

        const args = {
            cities: data[0],
            posts: data[1],
            comments: data[2],
        }

        checkResults(args)

        res.render('blog', args)
    }

With this PR this code will turn into:

    function checkResults(data) {
        for (let [key, value] of Object.entries(data)) {
            if (value[0]) {
                throw new Error(`Batch call '${key}' failed: ${value[0]}`)
            }
            data[key] = value[1]
        }
    }

    async function handler(req, res) {
        const {data} = await api.service('batch').create({
            call: {
                cities: ['cities::find'],
                posts: ['posts::find'],
                comments: ['comments::find'],
            }
        })

        checkResults(data)

        res.render('blog', data)
    }

1. No magic numbers (indexes).
2. Easier to write and modify code.
3. ???
4. Profit.

P.S. It is backward compatible.